### PR TITLE
Improve internationalization

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ module.exports = function (string) {
 }
 
 module.exports.words = function (string) {
-  return string.replace(/(^|\W)(\w)/g, function (m) {
+  return string.replace(/(^|[^a-zA-Z\u00C0-\u017F])([a-zA-Z\u00C0-\u017F])/g, function (m) {
     return m.toUpperCase()
   })
 }


### PR DESCRIPTION
The proposed regex improves internationalization. Allows accents, ñ, ç, and other widely used letters.
Before: `hello-cañapolísas => Hello-caÑApolÍSas`
Now: `hello-cañapolísas => Hello-Cañapolísas`

DISCLAIMER: Regex is taken from here: http://stackoverflow.com/questions/20690499/concrete-javascript-regex-for-accented-characters-diacritics
