### PR TITLE
Avoid matching on single quotes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ test('Capitalize each word', function (t) {
 })
 ```
 
+And ensure that quotes are handled within the string:
+
+```javascript
+test('Capitalize each word ensuring that quotes do not confuse it', function(t) {
+    t.plan(1)
+    t.equal(capitalize.words("it's a nice day"), "It's A Nice Day")
+})
+```
+
 ## Install
 
     npm install capitalize

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ module.exports = function (string) {
 }
 
 module.exports.words = function (string) {
-  return string.replace(/(^|\W)(\w)/g, function (m) {
+  return string.replace(/(^|[^a-zA-Z0-9_'])(\w)/g, function (m) {
     return m.toUpperCase()
   })
 }


### PR DESCRIPTION
The first group match in the regexp would match on a single quote and that resulted in results like this:

`it's a nice day` would become `It'S A Nice Day`

I have expanded the `\w` shortcut into the full version and added the single quote char: `[^a-zA-Z0-9_']`

I added a test to the README to cover this as well.
