### PR TITLE
Capitalize only first letter of each word. Leave the rest of letters …

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,15 +1,14 @@
-module.exports = function (string) {
-  string = string.toLowerCase();
+module.exports = function (string, preserve) {
+  if (!preserve) {
+    string = string.toLowerCase();
+  }
   return string.charAt(0).toUpperCase() + string.substring(1);
 }
 
-module.exports.words = function (string) {
-  return string.toLowerCase().replace(/(^|[^a-zA-Z\u00C0-\u017F'])([a-zA-Z\u00C0-\u017F])/g, function (m) {
-    return m.toUpperCase()
-  })
-}
-
-module.exports.wordsFirstLetterOnly = function (string) {
+module.exports.words = function (string, preserve) {
+  if (!preserve) {
+    string = string.toLowerCase();
+  }
   return string.replace(/(^|[^a-zA-Z\u00C0-\u017F'])([a-zA-Z\u00C0-\u017F])/g, function (m) {
     return m.toUpperCase()
   })

--- a/index.js
+++ b/index.js
@@ -8,3 +8,9 @@ module.exports.words = function (string) {
     return m.toUpperCase()
   })
 }
+
+module.exports.wordsFirstLetterOnly = function (string) {
+  return string.replace(/(^|[^a-zA-Z\u00C0-\u017F'])([a-zA-Z\u00C0-\u017F])/g, function (m) {
+    return m.toUpperCase()
+  })
+}


### PR DESCRIPTION
Hello. 
I’ve added a new method to capitalize only first letter of each word like CSS rule `text-transform: capitalize` do. 
I found this was a reason of my automated tests failed sometimes.