### PR TITLE
Excluding strings starting with numbers in regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,32 +31,32 @@ No matter the original case:
 ```javascript
 test('Capitalize first letter with original string...', function (t) {
   t.plan(2)
-  
+
   t.test('...in upper case', function (t1) {
     t1.plan(1)
     t1.equal(capitalize.words("UNITED STATES"), "United States")
   })
-  
+
   t.test('...in mixed case', function (t2) {
     t2.plan(1)
     t2.equal(capitalize.words("uNiTeD sTaTeS"), "United States")
   })
-  
+
 })
 
 test('Capitalize each word with original string...', function (t) {
   t.plan(2)
-  
+
   t.test('...in upper case', function (t1) {
     t1.plan(1)
     t1.equal(capitalize.words("UNITED STATES"), "United States")
   })
-  
+
   t.test('...in mixed case', function (t2) {
     t2.plan(1)
     t2.equal(capitalize.words("uNiTeD sTaTeS"), "United States")
   })
-  
+
 })
 ```
 
@@ -101,10 +101,19 @@ test('Capitalize words, preserving the case', function (t) {
 })
 ```
 
+and thanks to [@rubengmurray](https://github.com/grncdr/js-capitalize/pull/13), capitalize now handles shorthand ordinal numbers as would be expected:
+
+```javascript
+test('Capitalize words, handling shorthand ordinals (1st, 2nd, 3rd) correctly', function (t) {
+  t.plan(1)
+  t.equal(capitalize.words('1st place'), '1st Place')
+})
+```
+
 
 ## Install
 
-    npm install capitalize
+npm install capitalize
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ test('Capitalize words, handling shorthand ordinals (1st, 2nd, 3rd) correctly', 
 
 ## Install
 
-npm install capitalize
+    npm install capitalize
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports.words = function (string, preserve) {
   if (!preserve) {
     string = string.toLowerCase();
   }
-  return string.replace(/(^|[^a-zA-Z\u00C0-\u017F\u0400-\u04FF'])([a-zA-Z\u00C0-\u017F\u0400-\u04FF])/g, function (m) {
+  return string.replace(/(?!^[0-9])(^|[^a-zA-Z\u00C0-\u017F\u0400-\u04FF'])([a-zA-Z\u00C0-\u017F\u0400-\u04FF])/g, function (m) {
     return m.toUpperCase()
   })
 }


### PR DESCRIPTION
Exclude strings starting with number e.g 1st, 2nd, 3rd which currently come out as 1St, 2Nd, 3Rd.